### PR TITLE
Fix bugs in linux system

### DIFF
--- a/run_trackers.py
+++ b/run_trackers.py
@@ -129,7 +129,7 @@ def run_trackers(trackers, seqs, evalType, shiftTypeSet):
                 else:
                     r = Result(t, s.name, subS.startFrame, subS.endFrame,
                         res['type'], evalType, res['res'], res['fps'], None)
-                try: r.tmplsize = res['tmplsize'][0]
+                try: r.tmplsize = butil.d_to_f(res['tmplsize'][0])
                 except: pass
                 r.refresh_dict()
                 seqResults.append(r)

--- a/scripts/butil/seq_config.py
+++ b/scripts/butil/seq_config.py
@@ -126,7 +126,7 @@ def make_seq_configs(loadSeqs):
                     + 'check if config.py\'s DOWNLOAD_SEQS is True'
                 sys.exit(1)
 
-        imgfiles = os.listdir(imgSrc)
+        imgfiles = sorted(os.listdir(imgSrc))
         imgfiles = [x for x in imgfiles if x.split('.')[1] in ['jpg', 'png']]
         nz, ext, startFrame, endFrame = get_format(name, imgfiles)
         


### PR DESCRIPTION
Fix two bugs in linux system:
1. sort filenames return by os.listdir to provide the correct input for get_format
2. cast tmplsize from matlab double to python float to make it json serializable